### PR TITLE
Multi slice

### DIFF
--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -167,8 +167,6 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
         bool fIsData;
         bool fDebug;
 
-		std::map<int, art::Ptr<simb::MCParticle>> particleMap;
-
 		std::vector<int> primary_ids;
 		std::vector<int> sigmaZeroDaughter_ids;
 		std::vector<int> lambdaDaughter_ids;
@@ -285,7 +283,6 @@ hyperon::HyperonProduction::HyperonProduction(Parameters const& config)
 void hyperon::HyperonProduction::analyze(art::Event const& evt)
 {
     // Make sure our true->reco maps are clear
-	particleMap.clear();
     _hit_to_trackID.clear();
     _trackID_to_hits.clear();
     _mc_particle_map.clear();
@@ -340,10 +337,6 @@ void hyperon::HyperonProduction::analyze(art::Event const& evt)
 
 			const std::vector<art::Ptr<simb::MCParticle>> g4particles =
 				util::GetAssocProductVector<simb::MCParticle>(truth, evt, fGeneratorLabel, fG4Label);
-
-			for (const art::Ptr<simb::MCParticle> &g4p : g4particles) {
-				particleMap.insert(std::make_pair(g4p->TrackId(), g4p));
-			}
 
 			buildTruthHierarchy(g4particles);
 
@@ -881,9 +874,9 @@ void hyperon::HyperonProduction::buildTruthHierarchy(const std::vector<art::Ptr<
 
 	for (size_t i_d = 0; i_d < sigmaZeroDaughter_ids.size(); i_d++)
 	{
-		if (particleMap.find(sigmaZeroDaughter_ids.at(i_d)) == particleMap.end()) continue;
+		if (_mc_particle_map.find(sigmaZeroDaughter_ids.at(i_d)) == _mc_particle_map.end()) continue;
 
-		auto p = particleMap.at(sigmaZeroDaughter_ids.at(i_d));
+		auto p = _mc_particle_map.at(sigmaZeroDaughter_ids.at(i_d));
 
 		if (p->PdgCode() == pdg::Lambda) {
 			std::vector<int> _ids = getChildIds(p);
@@ -901,9 +894,9 @@ std::vector<int> hyperon::HyperonProduction::getChildIds(const art::Ptr<simb::MC
 	if (p->EndProcess() != "Decay" && !IsNeutron && !pdg::isKaon(p)) return _decay_ids;
 
 	for (int i_d = 0; i_d < p->NumberDaughters(); i_d++) {
-		if (particleMap.find(p->Daughter(i_d)) == particleMap.end()) continue;
+		if (_mc_particle_map.find(p->Daughter(i_d)) == _mc_particle_map.end()) continue;
 
-		art::Ptr<simb::MCParticle> daughter = particleMap.at(p->Daughter(i_d));
+		art::Ptr<simb::MCParticle> daughter = _mc_particle_map.at(p->Daughter(i_d));
 
 		if (daughter->PdgCode() > 10000) continue;
 

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -379,15 +379,15 @@ void hyperon::HyperonProduction::analyze(art::Event const& evt)
 	}
 
 	art::ValidHandle<std::vector<recob::Slice>> slice_handle =
-		evt.getValidHandle<std::vector<recob::Slice>>(fFlashMatchRecoLabel);
-    art::FindManyP<recob::PFParticle> slice_pfp_assoc(slice_handle, evt, fFlashMatchRecoLabel);
+		evt.getValidHandle<std::vector<recob::Slice>>(fPandoraRecoLabel);
+    art::FindManyP<recob::PFParticle> slice_pfp_assoc(slice_handle, evt, fPandoraRecoLabel);
 
 	art::ValidHandle<std::vector<recob::PFParticle>> pfpHandle =
-		evt.getValidHandle<std::vector<recob::PFParticle>>(fFlashMatchRecoLabel);
+		evt.getValidHandle<std::vector<recob::PFParticle>>(fPandoraRecoLabel);
 	art::FindManyP<recob::Track>  pfpTrackAssoc(pfpHandle, evt, fTrackLabel);
 	art::FindManyP<recob::Shower> pfpShowerAssoc(pfpHandle, evt, fShowerLabel);
 	art::FindManyP<larpandoraobj::PFParticleMetadata>
-		pfpMetaAssoc(pfpHandle, evt, fFlashMatchRecoLabel);
+		pfpMetaAssoc(pfpHandle, evt, fPandoraRecoLabel);
 
 	art::ValidHandle<std::vector<recob::Hit>> hitHandle =
 		evt.getValidHandle<std::vector<recob::Hit>>(fHitLabel);
@@ -402,14 +402,15 @@ void hyperon::HyperonProduction::analyze(art::Event const& evt)
 	for (const art::Ptr<recob::PFParticle> &nuSlicePFP : nuSlicePFPs)
 	{
         // Is the PFP in the neutrino hierarchy?
+        // This is important, so we don't pick up the CR hypothesis output
         const art::Ptr<recob::PFParticle> parentPFP = lar_pandora::LArPandoraHelper::GetParentPFParticle(_pfp_map, nuSlicePFP);
 
         if (!lar_pandora::LArPandoraHelper::IsNeutrino(parentPFP))
             continue;
 
-        unsigned int generation = lar_pandora::LArPandoraHelper::GetGeneration(_pfp_map, nuSlicePFP);
-
         // Let's just looking at primaries
+        const unsigned int generation = lar_pandora::LArPandoraHelper::GetGeneration(_pfp_map, nuSlicePFP);
+
         if (generation != 2)
             continue;
 
@@ -571,7 +572,7 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
     art::Handle<std::vector<recob::PFParticle>> pfp_handle;
     std::vector<art::Ptr<recob::PFParticle>> pfp_vector;
 
-    if (!evt.getByLabel(fFlashMatchRecoLabel, pfp_handle))
+    if (!evt.getByLabel(fPandoraRecoLabel, pfp_handle))
         throw cet::exception("HyperonProduction::fillPandoraMaps") << "No PFParticle Data Products Found! :(" << std::endl;
 
     art::fill_ptr_vector(pfp_vector, pfp_handle);
@@ -582,7 +583,7 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
     art::Handle<std::vector<recob::Slice>> slice_handle;
     std::vector<art::Ptr<recob::Slice>> slice_vector;
 
-    if (!evt.getByLabel(fFlashMatchRecoLabel, slice_handle))
+    if (!evt.getByLabel(fPandoraRecoLabel, slice_handle))
         throw cet::exception("HyperonProduction::fillPandoraMaps") << "No Slice Data Products Found! :(" << std::endl;
 
     art::fill_ptr_vector(slice_vector, slice_handle);
@@ -670,7 +671,7 @@ void hyperon::HyperonProduction::getTrueNuSliceID(art::Event const& evt)
     art::Handle<std::vector<recob::Slice>> slice_handle;
     std::vector<art::Ptr<recob::Slice>> slice_vector;
 
-    if (!evt.getByLabel(fFlashMatchRecoLabel, slice_handle))
+    if (!evt.getByLabel(fPandoraRecoLabel, slice_handle))
         throw cet::exception("HyperonProduction::getTrueNuSliceID") << "No Slice Data Products Found! :(" << std::endl;
 
     if (slice_handle.isValid())
@@ -678,7 +679,7 @@ void hyperon::HyperonProduction::getTrueNuSliceID(art::Event const& evt)
 
     _n_slices = slice_vector.size();
 
-    art::FindManyP<recob::Hit> hit_assoc = art::FindManyP<recob::Hit>(slice_handle, evt, fFlashMatchRecoLabel);
+    art::FindManyP<recob::Hit> hit_assoc = art::FindManyP<recob::Hit>(slice_handle, evt, fPandoraRecoLabel);
 
     // Now find true nu slice ID
     int true_slice_n_hits(-1);
@@ -729,16 +730,16 @@ std::vector<art::Ptr<recob::Hit>> hyperon::HyperonProduction::collectHitsFromClu
 
     art::Handle<std::vector<recob::PFParticle>> pfp_handle;
 
-    if (!evt.getByLabel(fFlashMatchRecoLabel, pfp_handle))
+    if (!evt.getByLabel(fPandoraRecoLabel, pfp_handle))
         throw cet::exception("HyperonProduction::CollectHitsFromClusters") << "No PFParticle Data Products Found! :(" << std::endl;
 
     art::Handle<std::vector<recob::Cluster>> cluster_handle;
 
-    if (!evt.getByLabel(fFlashMatchRecoLabel, cluster_handle)) 
+    if (!evt.getByLabel(fPandoraRecoLabel, cluster_handle)) 
         throw cet::exception("HyperonProduction::CollectHitsFromClusters") << "No Cluster Data Products Found! :(" << std::endl;
 
-    art::FindManyP<recob::Cluster> pfp_clusters_assoc = art::FindManyP<recob::Cluster>(pfp_handle, evt, fFlashMatchRecoLabel);
-    art::FindManyP<recob::Hit> cluster_hit_assoc = art::FindManyP<recob::Hit>(cluster_handle, evt, fFlashMatchRecoLabel);
+    art::FindManyP<recob::Cluster> pfp_clusters_assoc = art::FindManyP<recob::Cluster>(pfp_handle, evt, fPandoraRecoLabel);
+    art::FindManyP<recob::Hit> cluster_hit_assoc = art::FindManyP<recob::Hit>(cluster_handle, evt, fPandoraRecoLabel);
 
     std::vector<art::Ptr<recob::Cluster>> clusters = pfp_clusters_assoc.at(pfparticle.key());
 
@@ -755,34 +756,73 @@ std::vector<art::Ptr<recob::Hit>> hyperon::HyperonProduction::collectHitsFromClu
 
 void hyperon::HyperonProduction::getFlashMatchNuSliceID(art::Event const& evt)
 {
-	art::ValidHandle<std::vector<recob::Slice>> slice_handle =
-		evt.getValidHandle<std::vector<recob::Slice>>(fFlashMatchRecoLabel);
-	std::vector<art::Ptr<recob::Slice>> slice_vector;
+    art::Handle<std::vector<recob::PFParticle>> fm_pfp_handle;
+    std::vector<art::Ptr<recob::PFParticle>> fm_pfp_vector;
 
-	if (slice_handle.isValid())
-		art::fill_ptr_vector(slice_vector, slice_handle);
+    if (!evt.getByLabel(fFlashMatchRecoLabel, fm_pfp_handle))
+        throw cet::exception("HyperonProduction::getFlashMatchNuSliceID") << "No PFParticle Data Products Found! :(" << std::endl;
 
-	art::FindManyP<recob::PFParticle> slice_pfp_assoc(slice_handle, evt, fFlashMatchRecoLabel);
+    art::fill_ptr_vector(fm_pfp_vector, fm_pfp_handle);
 
-    // Should be at max one neutrino slice
-	for (const art::Ptr<recob::Slice> &slice : slice_vector)
-	{
-		// collect all PFPs associated with the current slice key
-		std::vector<art::Ptr<recob::PFParticle>> slicePFPs(slice_pfp_assoc.at(slice.key()));
+    std::vector<art::Ptr<recob::PFParticle>> neutrinoPFPs;
+    lar_pandora::LArPandoraHelper::SelectNeutrinoPFParticles(fm_pfp_vector, neutrinoPFPs);
 
-		for (const art::Ptr<recob::PFParticle> &slicePFP : slicePFPs)
-		{
-			const bool is_primary(slicePFP->IsPrimary());
-			const bool is_neutrino(std::abs(slicePFP->PdgCode()) == 12 || std::abs(slicePFP->PdgCode()) == 14);
+    if (neutrinoPFPs.size() > 1)
+    {
+        throw cet::exception("HyperonProduction::getFlashMatchNuSliceID") << "Too many neutrinos found!" << std::endl;
+    }
+    else if (neutrinoPFPs.size() == 1)
+    {
+        art::FindManyP<recob::Slice> fm_slice_assoc = art::FindManyP<recob::Slice>(fm_pfp_handle, evt, fFlashMatchRecoLabel);
+        const std::vector<art::Ptr<recob::Slice>> &fm_slices = fm_slice_assoc.at(neutrinoPFPs[0].key());
 
-			if (!(is_primary && is_neutrino))
-				continue;
+        if (fm_slices.empty())
+            return;
 
-			_flash_match_nu_slice_ID = slice.key();
+        // Get hits, and then work out if they also live in the pandoraPatRec reco?
+        const art::Ptr<recob::Slice> &fm_slice(fm_slices.at(0));
 
-			return;
-		}
-	}
+        art::Handle<std::vector<recob::Slice>> fm_slice_handle;
+
+        if (!evt.getByLabel(fFlashMatchRecoLabel, fm_slice_handle))
+            throw cet::exception("HyperonProduction::getFlashMatchNuSliceID") << "No Flash Match Slice Data Products Found!" << std::endl;
+
+        art::FindManyP<recob::Hit> fm_hit_assoc = art::FindManyP<recob::Hit>(fm_slice_handle, evt, fFlashMatchRecoLabel);
+        const std::vector<art::Ptr<recob::Hit>> &fm_slice_hits(fm_hit_assoc.at(fm_slice.key()));
+
+        if (fm_slice_hits.empty())
+            return;
+
+        // Get equivalent pandoraPatRec products
+        art::ValidHandle<std::vector<recob::Slice>> slice_handle =
+            evt.getValidHandle<std::vector<recob::Slice>>(fPandoraRecoLabel);
+
+        std::vector<art::Ptr<recob::Slice>> slice_vector;
+
+        if (slice_handle.isValid())
+            art::fill_ptr_vector(slice_vector, slice_handle);
+
+        art::FindManyP<recob::Hit> hit_assoc = art::FindManyP<recob::Hit>(slice_handle, evt, fPandoraRecoLabel);
+
+        // Loop through pandoraPatRecSlices
+        for (art::Ptr<recob::Slice> &slice : slice_vector)
+        {
+            const std::vector<art::Ptr<recob::Hit>> &slice_hits(hit_assoc.at(slice.key()));
+
+            // could loop over whichever is smaller - to save time...
+            const std::vector<art::Ptr<recob::Hit>> &hitsToLoop(slice_hits.size() < fm_slice_hits.size() ? slice_hits : fm_slice_hits);
+            const art::Ptr<recob::Hit> &hitToCompare(slice_hits.size() < fm_slice_hits.size() ? fm_slice_hits.front() : slice_hits.front());
+
+            for (const art::Ptr<recob::Hit> &hit : hitsToLoop)
+            {
+                if (hit.key() == hitToCompare.key())
+                {
+                    _flash_match_nu_slice_ID = slice->ID();
+                    return;
+                }
+            }
+        }
+    }
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -32,6 +32,7 @@
 #include "lardataobj/RecoBase/Shower.h"
 #include "lardataobj/RecoBase/Slice.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "lardataobj/RecoBase/Vertex.h"
 
 // larpandora
 #include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
@@ -238,9 +239,9 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
         // Reco pfp stuff
 		std::vector<int>    _pfp_pdg;
 		std::vector<double> _pfp_trk_shr_score;
-        std::vector<double> _pfp_x; // TODO: Set this!
-        std::vector<double> _pfp_y; // TODO: Set this! 
-        std::vector<double> _pfp_z; // TODO: Set this! 
+        std::vector<double> _pfp_x;
+        std::vector<double> _pfp_y;
+        std::vector<double> _pfp_z;
 
         /////////////////////////////
 		// Track Variables
@@ -345,20 +346,16 @@ void hyperon::HyperonProduction::analyze(art::Event const& evt)
     // Find the flash matched neutrino slice (if one exists)
     if (fDebug) std::cout << "Getting flash match slice ID..." << std::endl;
     getFlashMatchNuSliceID(evt);
-    std::cout << "_flash_match_nu_slice_ID: " << _flash_match_nu_slice_ID << std::endl;
 
     // Find the Pandora (highest topological score) neutrino slice (if one exists)
     if (fDebug) std::cout << "Getting the highest topological score slice ID..." << std::endl;
     getTopologicalScoreNuSliceID(evt);
-    std::cout << "_pandora_nu_slice_ID: " << _pandora_nu_slice_ID << std::endl;
 
     // Fill the reconstructed neutrino hierarchy variables (using flash match neutrino slice)
     if (fDebug) std::cout << "Filling Reconstructed Particle Variables..." << std::endl;
     getEventRecoInfo(evt, _flash_match_nu_slice_ID);
 
-    std::cout << "11111111111111" << std::endl;
 	fTree->Fill();
-    std::cout << "22222222222222" << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -491,8 +488,6 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
     art::fill_ptr_vector(mc_particle_vector, mc_particle_handle);
     lar_pandora::LArPandoraHelper::BuildMCParticleMap(mc_particle_vector, _mc_particle_map);
 
-    std::cout << "mc_particle_vector.size(): " << mc_particle_vector.size() << std::endl;
-
     // PFParticle map
     art::Handle<std::vector<recob::PFParticle>> pfp_handle;
     std::vector<art::Ptr<recob::PFParticle>> pfp_vector;
@@ -503,8 +498,6 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
     art::fill_ptr_vector(pfp_vector, pfp_handle);
 
     lar_pandora::LArPandoraHelper::BuildPFParticleMap(pfp_vector, _pfp_map);
-
-    std::cout << "pfp_vector.size(): " << pfp_vector.size() << std::endl;
 
     // Slice map
     art::Handle<std::vector<recob::Slice>> slice_handle;
@@ -517,8 +510,6 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
 
     for (const art::Ptr<recob::Slice> &slice : slice_vector)
         _slice_map[slice->ID()] = slice;
-
-    std::cout << "slice_vector: " << slice_vector.size() << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -560,9 +551,6 @@ void hyperon::HyperonProduction::fillMCParticleHitMaps(art::Event const& evt)
             _trackID_to_hits[trackID].push_back(hit.key());
         }
     }
-
-    std::cout << "_hit_to_trackID.size(): " << _hit_to_trackID.size() << std::endl;
-    std::cout << "_trackID_to_hits.size(): " << _trackID_to_hits.size() << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -603,16 +591,12 @@ void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
 	if (fIsData)
         return;
 
-    std::cout << "fIsData: " << fIsData << std::endl;
-
 	art::ValidHandle<std::vector<simb::MCTruth>> mcTruthHandle =
         evt.getValidHandle<std::vector<simb::MCTruth>>(fGeneratorLabel);
     std::vector<art::Ptr<simb::MCTruth>> mcTruthVector;
 
     if (mcTruthHandle.isValid())
         art::fill_ptr_vector(mcTruthVector, mcTruthHandle);
-
-    std::cout << "mcTruthVector.size(): " << mcTruthVector.size() << std::endl;
 
     // Fill truth information	
     for (const art::Ptr<simb::MCTruth> &truth : mcTruthVector)
@@ -642,8 +626,6 @@ void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
 
     if (fDebug) std::cout << "Filling MC Slice Info..." << std::endl;
     getTrueNuSliceID(evt);
-
-    std::cout << "_mc_lepton_pdg: " << _mc_lepton_pdg << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -867,8 +849,6 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 		if (fDebug)
 			FNLOG("flash match, or pandora slice not found");
 
-        std::cout << "HEY HEY HEY HEY HEY" << std::endl;
-
 		fillNull();
 		return;
 	}
@@ -880,8 +860,6 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 
 	const std::vector<art::Ptr<recob::PFParticle>> nu_slice_pfps(slice_pfp_assoc.at(_slice_map.at(nu_sliceID).key()));
 
-    std::cout << "nu_slice_pfps.size(): " << nu_slice_pfps.size() << std::endl;
-
 	for (const art::Ptr<recob::PFParticle> &nu_slice_pfp : nu_slice_pfps)
 	{
         // Is the PFP in the neutrino hierarchy?
@@ -890,8 +868,6 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 
         if (!lar_pandora::LArPandoraHelper::IsNeutrino(parentPFP))
             continue;
-
-        std::cout << "we have a neutrino child!" << std::endl;
 
         // Let's just looking at primaries
         const unsigned int generation = lar_pandora::LArPandoraHelper::GetGeneration(_pfp_map, nu_slice_pfp);
@@ -921,16 +897,18 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 
 void hyperon::HyperonProduction::getPFPRecoInfo(art::Event const& evt, const art::Ptr<recob::PFParticle> &pfparticle)
 {
-	art::ValidHandle<std::vector<recob::PFParticle>> pfpHandle =
+    // Pandora 'PDG'
+    _pfp_pdg.push_back(pfparticle->PdgCode());
+
+    // Track/shower score
+	art::ValidHandle<std::vector<recob::PFParticle>> pfp_handle =
 		evt.getValidHandle<std::vector<recob::PFParticle>>(fPandoraRecoLabel);
 
 	art::FindManyP<larpandoraobj::PFParticleMetadata>
-		pfpMetaAssoc(pfpHandle, evt, fPandoraRecoLabel);
-
-    _pfp_pdg.push_back(pfparticle->PdgCode());
+		pfp_meta_assoc(pfp_handle, evt, fPandoraRecoLabel);
 
     std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> pfp_metas =
-        pfpMetaAssoc.at(pfparticle.key());
+        pfp_meta_assoc.at(pfparticle.key());
 
     if ((!pfp_metas.empty()) && (pfp_metas.at(0)->GetPropertiesMap().find("TrackScore") != 
         pfp_metas.at(0)->GetPropertiesMap().end()))
@@ -941,6 +919,29 @@ void hyperon::HyperonProduction::getPFPRecoInfo(art::Event const& evt, const art
     {
         _pfp_trk_shr_score.push_back(bogus::DOUBLE);
     }
+
+    // Vertex
+	art::FindManyP<recob::Vertex>
+		pfp_vertex_assoc(pfp_handle, evt, fPandoraRecoLabel);
+
+    std::vector<art::Ptr<recob::Vertex>> pfp_vertices =
+        pfp_vertex_assoc.at(pfparticle.key());
+
+    if (!pfp_vertices.empty())
+    {
+        const art::Ptr<recob::Vertex> &vertex = pfp_vertices.at(0);
+
+        _pfp_x.push_back(vertex->position().X());
+        _pfp_y.push_back(vertex->position().Y());
+        _pfp_z.push_back(vertex->position().Z());
+    }
+    else
+    {
+        _pfp_x.push_back(bogus::DOUBLE);
+        _pfp_y.push_back(bogus::DOUBLE);
+        _pfp_z.push_back(bogus::DOUBLE);
+    }
+
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1063,6 +1064,8 @@ void hyperon::HyperonProduction::getTrackVariables(art::Event const& evt, const 
     _trk_mean_dedx_plane1.push_back(dedx.plane1);
     _trk_mean_dedx_plane2.push_back(dedx.plane2);
     _trk_three_plane_dedx.push_back(dedx.three_plane_average);
+
+    _trk_llrpid.push_back(bogus::DOUBLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1083,6 +1086,7 @@ void hyperon::HyperonProduction::getBogusTrackVariables()
     _trk_mean_dedx_plane1.push_back(bogus::DOUBLE); 
     _trk_mean_dedx_plane2.push_back(bogus::DOUBLE); 
     _trk_three_plane_dedx.push_back(bogus::DOUBLE); 
+    _trk_llrpid.push_back(bogus::DOUBLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1121,6 +1125,12 @@ void hyperon::HyperonProduction::getShowerVariables(art::Event const& evt, const
 	_shr_dir_x.push_back(shower->Direction().X());
 	_shr_dir_y.push_back(shower->Direction().Y());
 	_shr_dir_z.push_back(shower->Direction().Z());
+    _shr_energy_plane0.push_back(bogus::DOUBLE);
+    _shr_energy_plane1.push_back(bogus::DOUBLE);
+    _shr_energy_plane2.push_back(bogus::DOUBLE);
+    _shr_dedx_plane0.push_back(bogus::DOUBLE);
+    _shr_dedx_plane1.push_back(bogus::DOUBLE);
+    _shr_dedx_plane2.push_back(bogus::DOUBLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1135,6 +1145,12 @@ void hyperon::HyperonProduction::getBogusShowerVariables()
 	_shr_dir_x.push_back(bogus::DOUBLE);
 	_shr_dir_y.push_back(bogus::DOUBLE);
 	_shr_dir_z.push_back(bogus::DOUBLE);
+    _shr_energy_plane0.push_back(bogus::DOUBLE);
+    _shr_energy_plane1.push_back(bogus::DOUBLE);
+    _shr_energy_plane2.push_back(bogus::DOUBLE);
+    _shr_dedx_plane0.push_back(bogus::DOUBLE);
+    _shr_dedx_plane1.push_back(bogus::DOUBLE);
+    _shr_dedx_plane2.push_back(bogus::DOUBLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1254,8 +1270,6 @@ void hyperon::HyperonProduction::clearTreeVariables()
 // products fails.
 void hyperon::HyperonProduction::fillNull()
 {
-    std::cout << "FILLING NULL!!!" << std::endl;
-
 	clearTreeVariables();
 
 	fTree->Fill();

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -15,7 +15,7 @@
 #include "art/Framework/Principal/SubRun.h"
 #include "art/Framework/Services/Optional/TFileDirectory.h"
 #include "art/Framework/Services/Optional/TFileService.h"
-#include "canvas/Persistency/Common/FindMany.h"				
+#include "canvas/Persistency/Common/FindMany.h"
 #include "canvas/Persistency/Common/FindManyP.h"
 #include "canvas/Utilities/InputTag.h"
 #include "cetlib_except/exception.h"
@@ -141,7 +141,7 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
         int getLeadEMTrackID(const art::Ptr<simb::MCParticle> &mc_particle);
         void getEventMCInfo(art::Event const& evt);
         void getTrueNuSliceID(art::Event const& evt);
-        std::vector<art::Ptr<recob::Hit>> collectHitsFromClusters(art::Event const& evt, 
+        std::vector<art::Ptr<recob::Hit>> collectHitsFromClusters(art::Event const& evt,
             const art::Ptr<recob::PFParticle> &pfparticle);
         void getFlashMatchNuSliceID(art::Event const& evt);
         void getTopologicalScoreNuSliceID(art::Event const& evt);
@@ -260,7 +260,7 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
 		std::vector<double> _trk_mean_dedx_plane1;
 		std::vector<double> _trk_mean_dedx_plane2;
 		std::vector<double> _trk_three_plane_dedx;
-        std::vector<double> _trk_llrpid; // TODO: Set this! 
+        std::vector<double> _trk_llrpid; // TODO: Set this!
 
         /////////////////////////////
 		// Shower Variables
@@ -365,16 +365,16 @@ void hyperon::HyperonProduction::beginJob()
 	art::ServiceHandle<art::TFileService> tfs;
 	fTree = tfs->make<TTree>("OutputTree", "Output TTree");
 
-    /////////////////////////////
-    // Event ID
-    /////////////////////////////
+	/////////////////////////////
+	// Event ID
+	/////////////////////////////
 	fTree->Branch("run",    &_run);
 	fTree->Branch("subrun", &_subrun);
 	fTree->Branch("event",  &_event);
 
-    /////////////////////////////
-    // Event MC Info
-    /////////////////////////////
+	/////////////////////////////
+	// Event MC Info
+	/////////////////////////////
 	fTree->Branch("n_mctruths",                  &_n_mctruths);
 	fTree->Branch("mc_nu_pdg",                   &_mc_nu_pdg);
 	fTree->Branch("mc_nu_q2",                    &_mc_nu_q2);
@@ -385,81 +385,81 @@ void hyperon::HyperonProduction::beginJob()
 	fTree->Branch("mc_nu_pos_z",                 &_mc_nu_pos_z);
 	fTree->Branch("mc_lepton_pdg",               &_mc_lepton_pdg);
 	fTree->Branch("mc_lepton_mom",               &_mc_lepton_mom);
-    fTree->Branch("true_nu_slice_ID",            &_true_nu_slice_ID);
-    fTree->Branch("true_nu_slice_completeness",  &_true_nu_slice_completeness);
-    fTree->Branch("true_nu_slice_purity",        &_true_nu_slice_purity);
+	fTree->Branch("true_nu_slice_ID",            &_true_nu_slice_ID);
+	fTree->Branch("true_nu_slice_completeness",  &_true_nu_slice_completeness);
+	fTree->Branch("true_nu_slice_purity",        &_true_nu_slice_purity);
 	fTree->Branch("n_slices",                    &_n_slices);
 
-    /////////////////////////////
-    // FlashMatch Slice Info
-    /////////////////////////////
-    fTree->Branch("flash_match_nu_slice_ID",     &_flash_match_nu_slice_ID);
+	/////////////////////////////
+	// FlashMatch Slice Info
+	/////////////////////////////
+	fTree->Branch("flash_match_nu_slice_ID",     &_flash_match_nu_slice_ID);
 
-    /////////////////////////////
-    // Pandora Slice Info
-    /////////////////////////////
-    fTree->Branch("pandora_nu_slice_ID",         &_pandora_nu_slice_ID);
+	/////////////////////////////
+	// Pandora Slice Info
+	/////////////////////////////
+	fTree->Branch("pandora_nu_slice_ID",         &_pandora_nu_slice_ID);
 
-    /////////////////////////////
-    // PFParticle Variables
-    /////////////////////////////
-    // True stuff
-    fTree->Branch("pfp_purity",        & _pfp_purity);
-	fTree->Branch("pfp_completeness",  & _pfp_completeness);
-    fTree->Branch("pfp_has_truth",     & _pfp_has_truth);
-    fTree->Branch("pfp_trackID",       & _pfp_trackID);
-    fTree->Branch("pfp_true_pdg",      & _pfp_true_pdg);
-	fTree->Branch("pfp_true_energy",   & _pfp_true_energy);
-    fTree->Branch("pfp_true_ke",       & _pfp_true_ke);
-	fTree->Branch("pfp_true_px",       & _pfp_true_px);
-	fTree->Branch("pfp_true_py",       & _pfp_true_py);
-	fTree->Branch("pfp_true_pz",       & _pfp_true_pz);
-	fTree->Branch("pfp_true_length",   & _pfp_true_length);
-	fTree->Branch("pfp_true_origin",   & _pfp_true_origin);
+	/////////////////////////////
+	// PFParticle Variables
+	/////////////////////////////
+	// True stuff
+	fTree->Branch("pfp_purity",        &_pfp_purity);
+	fTree->Branch("pfp_completeness",  &_pfp_completeness);
+	fTree->Branch("pfp_has_truth",     &_pfp_has_truth);
+	fTree->Branch("pfp_trackID",       &_pfp_trackID);
+	fTree->Branch("pfp_true_pdg",      &_pfp_true_pdg);
+	fTree->Branch("pfp_true_energy",   &_pfp_true_energy);
+	fTree->Branch("pfp_true_ke",       &_pfp_true_ke);
+	fTree->Branch("pfp_true_px",       &_pfp_true_px);
+	fTree->Branch("pfp_true_py",       &_pfp_true_py);
+	fTree->Branch("pfp_true_pz",       &_pfp_true_pz);
+	fTree->Branch("pfp_true_length",   &_pfp_true_length);
+	fTree->Branch("pfp_true_origin",   &_pfp_true_origin);
 
-    // Reco pfp stuff
-    fTree->Branch("pfp_pdg",            & _pfp_pdg);
-    fTree->Branch("pfp_trk_shr_score",  & _pfp_trk_shr_score);
-    fTree->Branch("pfp_x",              & _pfp_x);
-    fTree->Branch("pfp_y",              & _pfp_y);
-    fTree->Branch("pfp_z",              & _pfp_z);
+	// Reco pfp stuff
+	fTree->Branch("pfp_pdg",            &_pfp_pdg);
+	fTree->Branch("pfp_trk_shr_score",  &_pfp_trk_shr_score);
+	fTree->Branch("pfp_x",              &_pfp_x);
+	fTree->Branch("pfp_y",              &_pfp_y);
+	fTree->Branch("pfp_z",              &_pfp_z);
 
-    /////////////////////////////
-    // Track Variables
-    /////////////////////////////
-	fTree->Branch("trk_length",              & _trk_length);
-	fTree->Branch("trk_start_x",             & _trk_start_x);
-	fTree->Branch("trk_start_y",             & _trk_start_y);
-	fTree->Branch("trk_start_z",             & _trk_start_z);
-	fTree->Branch("trk_end_x",               & _trk_end_x);
-	fTree->Branch("trk_end_y",               & _trk_end_y);
-	fTree->Branch("trk_end_z",               & _trk_end_z);
-	fTree->Branch("trk_dir_x",               & _trk_dir_x);
-	fTree->Branch("trk_dir_y",               & _trk_dir_y);
-	fTree->Branch("trk_dir_z",               & _trk_dir_z);
-	fTree->Branch("trk_mean_dedx_plane0",    & _trk_mean_dedx_plane0);
-	fTree->Branch("trk_mean_dedx_plane1",    & _trk_mean_dedx_plane1);
-	fTree->Branch("trk_mean_dedx_plane2",    & _trk_mean_dedx_plane2);
-	fTree->Branch("trk_three_plane_dedx",    & _trk_three_plane_dedx);
-    fTree->Branch("trk_llrpid",              & _trk_llrpid);
+	/////////////////////////////
+	// Track Variables
+	/////////////////////////////
+	fTree->Branch("trk_length",              &_trk_length);
+	fTree->Branch("trk_start_x",             &_trk_start_x);
+	fTree->Branch("trk_start_y",             &_trk_start_y);
+	fTree->Branch("trk_start_z",             &_trk_start_z);
+	fTree->Branch("trk_end_x",               &_trk_end_x);
+	fTree->Branch("trk_end_y",               &_trk_end_y);
+	fTree->Branch("trk_end_z",               &_trk_end_z);
+	fTree->Branch("trk_dir_x",               &_trk_dir_x);
+	fTree->Branch("trk_dir_y",               &_trk_dir_y);
+	fTree->Branch("trk_dir_z",               &_trk_dir_z);
+	fTree->Branch("trk_mean_dedx_plane0",    &_trk_mean_dedx_plane0);
+	fTree->Branch("trk_mean_dedx_plane1",    &_trk_mean_dedx_plane1);
+	fTree->Branch("trk_mean_dedx_plane2",    &_trk_mean_dedx_plane2);
+	fTree->Branch("trk_three_plane_dedx",    &_trk_three_plane_dedx);
+	fTree->Branch("trk_llrpid",              &_trk_llrpid);
 
-    /////////////////////////////
-    // Shower Variables
-    /////////////////////////////
-	fTree->Branch("shr_length",         & _shr_length);
-	fTree->Branch("shr_open_angle",     & _shr_open_angle);
-	fTree->Branch("shr_start_x",        & _shr_start_x);
-	fTree->Branch("shr_start_y",        & _shr_start_y);
-	fTree->Branch("shr_start_z",        & _shr_start_z);
-	fTree->Branch("shr_dir_x",          & _shr_dir_x);
-	fTree->Branch("shr_dir_y",          & _shr_dir_y);
-	fTree->Branch("shr_dir_z",          & _shr_dir_z);
-    fTree->Branch("shr_energy_plane0",  & _shr_energy_plane0);
-    fTree->Branch("shr_energy_plane1",  & _shr_energy_plane1);
-    fTree->Branch("shr_energy_plane2",  & _shr_energy_plane2);
-    fTree->Branch("shr_dedx_plane0",    & _shr_dedx_plane0);
-    fTree->Branch("shr_dedx_plane1",    & _shr_dedx_plane1);
-    fTree->Branch("shr_dedx_plane2",    & _shr_dedx_plane2);
+	/////////////////////////////
+	// Shower Variables
+	/////////////////////////////
+	fTree->Branch("shr_length",         &_shr_length);
+	fTree->Branch("shr_open_angle",     &_shr_open_angle);
+	fTree->Branch("shr_start_x",        &_shr_start_x);
+	fTree->Branch("shr_start_y",        &_shr_start_y);
+	fTree->Branch("shr_start_z",        &_shr_start_z);
+	fTree->Branch("shr_dir_x",          &_shr_dir_x);
+	fTree->Branch("shr_dir_y",          &_shr_dir_y);
+	fTree->Branch("shr_dir_z",          &_shr_dir_z);
+	fTree->Branch("shr_energy_plane0",  &_shr_energy_plane0);
+	fTree->Branch("shr_energy_plane1",  &_shr_energy_plane1);
+	fTree->Branch("shr_energy_plane2",  &_shr_energy_plane2);
+	fTree->Branch("shr_dedx_plane0",    &_shr_dedx_plane0);
+	fTree->Branch("shr_dedx_plane1",    &_shr_dedx_plane1);
+	fTree->Branch("shr_dedx_plane2",    &_shr_dedx_plane2);
 
 	//fTree->Branch("n_primary_tracks",        & _n_primary_tracks);
 	//fTree->Branch("n_primary_showers", &_n_primary_showers);
@@ -526,7 +526,7 @@ void hyperon::HyperonProduction::fillMCParticleHitMaps(art::Event const& evt)
     art::fill_ptr_vector(hit_vector, hit_handle);
 
     // Get backtracker info
-    art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData> assoc_mc_particle = 
+    art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData> assoc_mc_particle =
         art::FindManyP<simb::MCParticle, anab::BackTrackerHitMatchingData>(hit_handle, evt, fHitTruthAssnsLabel);
 
     // Truth match
@@ -598,7 +598,7 @@ void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
     if (mcTruthHandle.isValid())
         art::fill_ptr_vector(mcTruthVector, mcTruthHandle);
 
-    // Fill truth information	
+    // Fill truth information
     for (const art::Ptr<simb::MCTruth> &truth : mcTruthVector)
 	{
         _n_mctruths++;
@@ -635,7 +635,7 @@ void hyperon::HyperonProduction::getTrueNuSliceID(art::Event const& evt)
     // Get slice information
 	art::ValidHandle<std::vector<recob::Slice>> slice_handle =
         evt.getValidHandle<std::vector<recob::Slice>>(fPandoraRecoLabel);
-    std::vector<art::Ptr<recob::Slice>> slice_vector;   
+    std::vector<art::Ptr<recob::Slice>> slice_vector;
 
     if (slice_handle.isValid())
         art::fill_ptr_vector(slice_vector, slice_handle);
@@ -686,7 +686,7 @@ void hyperon::HyperonProduction::getTrueNuSliceID(art::Event const& evt)
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 
-std::vector<art::Ptr<recob::Hit>> hyperon::HyperonProduction::collectHitsFromClusters(art::Event const& evt, 
+std::vector<art::Ptr<recob::Hit>> hyperon::HyperonProduction::collectHitsFromClusters(art::Event const& evt,
     const art::Ptr<recob::PFParticle> &pfparticle)
 {
     std::vector<art::Ptr<recob::Hit>> hits;
@@ -698,7 +698,7 @@ std::vector<art::Ptr<recob::Hit>> hyperon::HyperonProduction::collectHitsFromClu
 
     art::Handle<std::vector<recob::Cluster>> cluster_handle;
 
-    if (!evt.getByLabel(fPandoraRecoLabel, cluster_handle)) 
+    if (!evt.getByLabel(fPandoraRecoLabel, cluster_handle))
         throw cet::exception("HyperonProduction::CollectHitsFromClusters") << "No Cluster Data Products Found! :(" << std::endl;
 
     art::FindManyP<recob::Cluster> pfp_clusters_assoc = art::FindManyP<recob::Cluster>(pfp_handle, evt, fPandoraRecoLabel);
@@ -800,7 +800,7 @@ void hyperon::HyperonProduction::getTopologicalScoreNuSliceID(art::Event const& 
 	if (slice_handle.isValid())
 		art::fill_ptr_vector(slice_vector, slice_handle);
 
-    art::ValidHandle<std::vector<recob::PFParticle>> pfp_handle = 
+    art::ValidHandle<std::vector<recob::PFParticle>> pfp_handle =
         evt.getValidHandle<std::vector<recob::PFParticle>>(fPandoraRecoLabel);
 
     art::FindManyP<recob::PFParticle> pfp_assoc = art::FindManyP<recob::PFParticle>(slice_handle, evt, fPandoraRecoLabel);
@@ -879,7 +879,7 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
         getPFPRecoInfo(evt, nu_slice_pfp);
 
         // Get PFP truth matching variables
-        if (!fIsData) 
+        if (!fIsData)
             getMCParticleVariables(evt, nu_slice_pfp);
         else
             getBogusMCParticleVariables();
@@ -910,7 +910,7 @@ void hyperon::HyperonProduction::getPFPRecoInfo(art::Event const& evt, const art
     std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> pfp_metas =
         pfp_meta_assoc.at(pfparticle.key());
 
-    if ((!pfp_metas.empty()) && (pfp_metas.at(0)->GetPropertiesMap().find("TrackScore") != 
+    if ((!pfp_metas.empty()) && (pfp_metas.at(0)->GetPropertiesMap().find("TrackScore") !=
         pfp_metas.at(0)->GetPropertiesMap().end()))
     {
         _pfp_trk_shr_score.push_back(pfp_metas.at(0)->GetPropertiesMap().at("TrackScore"));
@@ -977,9 +977,9 @@ void hyperon::HyperonProduction::getMCParticleVariables(art::Event const& evt, c
         }
     }
 
-	if (_mc_particle_map.find(matched_trackID) != _mc_particle_map.end()) 
+	if (_mc_particle_map.find(matched_trackID) != _mc_particle_map.end())
     {
-        const art::Ptr<simb::MCParticle> &matched_mc_particle(_mc_particle_map.at(matched_trackID)); 
+        const art::Ptr<simb::MCParticle> &matched_mc_particle(_mc_particle_map.at(matched_trackID));
 
         _pfp_has_truth.push_back(true);
         _pfp_trackID.push_back(matched_mc_particle->TrackId());
@@ -1059,7 +1059,7 @@ void hyperon::HyperonProduction::getTrackVariables(art::Event const& evt, const 
         util::GetAssocProductVector<anab::Calorimetry>(track, evt, fTrackLabel, fCaloLabel);
 
     auto dedx = alg::ThreePlaneMeandEdX(track, calos);
-			
+
     _trk_mean_dedx_plane0.push_back(dedx.plane0);
     _trk_mean_dedx_plane1.push_back(dedx.plane1);
     _trk_mean_dedx_plane2.push_back(dedx.plane2);
@@ -1073,26 +1073,26 @@ void hyperon::HyperonProduction::getTrackVariables(art::Event const& evt, const 
 void hyperon::HyperonProduction::getBogusTrackVariables()
 {
 	_trk_length.push_back(bogus::DOUBLE);
-	_trk_start_x.push_back(bogus::DOUBLE); 
-	_trk_start_y.push_back(bogus::DOUBLE); 
-	_trk_start_z.push_back(bogus::DOUBLE); 
-	_trk_end_x.push_back(bogus::DOUBLE); 
-	_trk_end_y.push_back(bogus::DOUBLE); 
-	_trk_end_z.push_back(bogus::DOUBLE); 
-	_trk_dir_x.push_back(bogus::DOUBLE); 
-	_trk_dir_y.push_back(bogus::DOUBLE); 
-	_trk_dir_z.push_back(bogus::DOUBLE); 
-    _trk_mean_dedx_plane0.push_back(bogus::DOUBLE); 
-    _trk_mean_dedx_plane1.push_back(bogus::DOUBLE); 
-    _trk_mean_dedx_plane2.push_back(bogus::DOUBLE); 
-    _trk_three_plane_dedx.push_back(bogus::DOUBLE); 
-    _trk_llrpid.push_back(bogus::DOUBLE);
+	_trk_start_x.push_back(bogus::DOUBLE);
+	_trk_start_y.push_back(bogus::DOUBLE);
+	_trk_start_z.push_back(bogus::DOUBLE);
+	_trk_end_x.push_back(bogus::DOUBLE);
+	_trk_end_y.push_back(bogus::DOUBLE);
+	_trk_end_z.push_back(bogus::DOUBLE);
+	_trk_dir_x.push_back(bogus::DOUBLE);
+	_trk_dir_y.push_back(bogus::DOUBLE);
+	_trk_dir_z.push_back(bogus::DOUBLE);
+	_trk_mean_dedx_plane0.push_back(bogus::DOUBLE);
+	_trk_mean_dedx_plane1.push_back(bogus::DOUBLE);
+	_trk_mean_dedx_plane2.push_back(bogus::DOUBLE);
+	_trk_three_plane_dedx.push_back(bogus::DOUBLE);
+	_trk_llrpid.push_back(bogus::DOUBLE);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void hyperon::HyperonProduction::getShowerVariables(art::Event const& evt, const art::Ptr<recob::PFParticle> &pfparticle)
-{	
+{
 	art::ValidHandle<std::vector<recob::PFParticle>> pfp_handle =
 		evt.getValidHandle<std::vector<recob::PFParticle>>(fPandoraRecoLabel);
 
@@ -1136,7 +1136,7 @@ void hyperon::HyperonProduction::getShowerVariables(art::Event const& evt, const
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 void hyperon::HyperonProduction::getBogusShowerVariables()
-{	
+{
     _shr_length.push_back(bogus::LENGTH);
     _shr_open_angle.push_back(bogus::ANGLE);
 	_shr_start_x.push_back(bogus::DOUBLE);

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -345,16 +345,20 @@ void hyperon::HyperonProduction::analyze(art::Event const& evt)
     // Find the flash matched neutrino slice (if one exists)
     if (fDebug) std::cout << "Getting flash match slice ID..." << std::endl;
     getFlashMatchNuSliceID(evt);
+    std::cout << "_flash_match_nu_slice_ID: " << _flash_match_nu_slice_ID << std::endl;
 
     // Find the Pandora (highest topological score) neutrino slice (if one exists)
     if (fDebug) std::cout << "Getting the highest topological score slice ID..." << std::endl;
     getTopologicalScoreNuSliceID(evt);
+    std::cout << "_pandora_nu_slice_ID: " << _pandora_nu_slice_ID << std::endl;
 
     // Fill the reconstructed neutrino hierarchy variables (using flash match neutrino slice)
     if (fDebug) std::cout << "Filling Reconstructed Particle Variables..." << std::endl;
     getEventRecoInfo(evt, _flash_match_nu_slice_ID);
 
+    std::cout << "11111111111111" << std::endl;
 	fTree->Fill();
+    std::cout << "22222222222222" << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -384,20 +388,20 @@ void hyperon::HyperonProduction::beginJob()
 	fTree->Branch("mc_nu_pos_z",                 &_mc_nu_pos_z);
 	fTree->Branch("mc_lepton_pdg",               &_mc_lepton_pdg);
 	fTree->Branch("mc_lepton_mom",               &_mc_lepton_mom);
-    fTree->Branch("true_nu_slice_ID",            & _true_nu_slice_ID);
-    fTree->Branch("true_nu_slice_completeness",  & _true_nu_slice_completeness);
-    fTree->Branch("true_nu_slice_purity",        & _true_nu_slice_purity);
-	fTree->Branch("n_slices",                    & _n_slices);
+    fTree->Branch("true_nu_slice_ID",            &_true_nu_slice_ID);
+    fTree->Branch("true_nu_slice_completeness",  &_true_nu_slice_completeness);
+    fTree->Branch("true_nu_slice_purity",        &_true_nu_slice_purity);
+	fTree->Branch("n_slices",                    &_n_slices);
 
     /////////////////////////////
     // FlashMatch Slice Info
     /////////////////////////////
-    fTree->Branch("flash_match_nu_slice_ID",     & _flash_match_nu_slice_ID);
+    fTree->Branch("flash_match_nu_slice_ID",     &_flash_match_nu_slice_ID);
 
     /////////////////////////////
     // Pandora Slice Info
     /////////////////////////////
-    fTree->Branch("pandora_nu_slice_ID",         & _pandora_nu_slice_ID);
+    fTree->Branch("pandora_nu_slice_ID",         &_pandora_nu_slice_ID);
 
     /////////////////////////////
     // PFParticle Variables
@@ -481,11 +485,13 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
     art::Handle<std::vector<simb::MCParticle>> mc_particle_handle;
     std::vector<art::Ptr<simb::MCParticle>> mc_particle_vector;
 
-    if (!evt.getByLabel(fGeneratorLabel, mc_particle_handle))
+    if (!evt.getByLabel(fG4Label, mc_particle_handle))
         throw cet::exception("HyperonProduction::fillPandoraMaps") << "No MCParticle Data Products Found! :(" << std::endl;
 
     art::fill_ptr_vector(mc_particle_vector, mc_particle_handle);
     lar_pandora::LArPandoraHelper::BuildMCParticleMap(mc_particle_vector, _mc_particle_map);
+
+    std::cout << "mc_particle_vector.size(): " << mc_particle_vector.size() << std::endl;
 
     // PFParticle map
     art::Handle<std::vector<recob::PFParticle>> pfp_handle;
@@ -498,6 +504,8 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
 
     lar_pandora::LArPandoraHelper::BuildPFParticleMap(pfp_vector, _pfp_map);
 
+    std::cout << "pfp_vector.size(): " << pfp_vector.size() << std::endl;
+
     // Slice map
     art::Handle<std::vector<recob::Slice>> slice_handle;
     std::vector<art::Ptr<recob::Slice>> slice_vector;
@@ -509,6 +517,8 @@ void hyperon::HyperonProduction::fillPandoraMaps(art::Event const& evt)
 
     for (const art::Ptr<recob::Slice> &slice : slice_vector)
         _slice_map[slice->ID()] = slice;
+
+    std::cout << "slice_vector: " << slice_vector.size() << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -550,6 +560,9 @@ void hyperon::HyperonProduction::fillMCParticleHitMaps(art::Event const& evt)
             _trackID_to_hits[trackID].push_back(hit.key());
         }
     }
+
+    std::cout << "_hit_to_trackID.size(): " << _hit_to_trackID.size() << std::endl;
+    std::cout << "_trackID_to_hits.size(): " << _trackID_to_hits.size() << std::endl;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -587,8 +600,10 @@ int hyperon::HyperonProduction::getLeadEMTrackID(const art::Ptr<simb::MCParticle
 void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
 {
 	// Check if this is an MC file.
-	if (!fIsData)
+	if (fIsData)
         return;
+
+    std::cout << "fIsData: " << fIsData << std::endl;
 
 	art::ValidHandle<std::vector<simb::MCTruth>> mcTruthHandle =
         evt.getValidHandle<std::vector<simb::MCTruth>>(fGeneratorLabel);
@@ -596,6 +611,8 @@ void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
 
     if (mcTruthHandle.isValid())
         art::fill_ptr_vector(mcTruthVector, mcTruthHandle);
+
+    std::cout << "mcTruthVector.size(): " << mcTruthVector.size() << std::endl;
 
     // Fill truth information	
     for (const art::Ptr<simb::MCTruth> &truth : mcTruthVector)
@@ -625,6 +642,8 @@ void hyperon::HyperonProduction::getEventMCInfo(art::Event const& evt)
 
     if (fDebug) std::cout << "Filling MC Slice Info..." << std::endl;
     getTrueNuSliceID(evt);
+
+    std::cout << "_mc_lepton_pdg: " << _mc_lepton_pdg << std::endl;
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -848,6 +867,8 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 		if (fDebug)
 			FNLOG("flash match, or pandora slice not found");
 
+        std::cout << "HEY HEY HEY HEY HEY" << std::endl;
+
 		fillNull();
 		return;
 	}
@@ -859,6 +880,8 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 
 	const std::vector<art::Ptr<recob::PFParticle>> nu_slice_pfps(slice_pfp_assoc.at(_slice_map.at(nu_sliceID).key()));
 
+    std::cout << "nu_slice_pfps.size(): " << nu_slice_pfps.size() << std::endl;
+
 	for (const art::Ptr<recob::PFParticle> &nu_slice_pfp : nu_slice_pfps)
 	{
         // Is the PFP in the neutrino hierarchy?
@@ -867,6 +890,8 @@ void hyperon::HyperonProduction::getEventRecoInfo(art::Event const& evt, const i
 
         if (!lar_pandora::LArPandoraHelper::IsNeutrino(parentPFP))
             continue;
+
+        std::cout << "we have a neutrino child!" << std::endl;
 
         // Let's just looking at primaries
         const unsigned int generation = lar_pandora::LArPandoraHelper::GetGeneration(_pfp_map, nu_slice_pfp);
@@ -1133,7 +1158,7 @@ void hyperon::HyperonProduction::clearTreeVariables()
     /////////////////////////////
     // Event MC Info
     /////////////////////////////
-	_n_mctruths                 = 0;
+	_n_mctruths  = 0;
 	_mc_nu_pdg   = bogus::PDG;
 	_mc_nu_q2    = bogus::DOUBLE;
 	_mc_nu_pos_x = bogus::POS;
@@ -1229,6 +1254,8 @@ void hyperon::HyperonProduction::clearTreeVariables()
 // products fails.
 void hyperon::HyperonProduction::fillNull()
 {
+    std::cout << "FILLING NULL!!!" << std::endl;
+
 	clearTreeVariables();
 
 	fTree->Fill();

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -660,7 +660,7 @@ void hyperon::HyperonProduction::getTrueNuSliceID(art::Event const& evt)
     art::Handle<std::vector<recob::Slice>> slice_handle;
     std::vector<art::Ptr<recob::Slice>> slice_vector;
 
-    if (!evt.getByLabel(fPandoraRecoLabel, slice_handle))
+    if (!evt.getByLabel(fFlashMatchRecoLabel, slice_handle))
         throw cet::exception("HyperonProduction::getTrueNuSliceID") << "No Slice Data Products Found! :(" << std::endl;
 
     art::FindManyP<recob::Hit> hit_assoc = art::FindManyP<recob::Hit>(slice_handle, evt, fFlashMatchRecoLabel);

--- a/HyperonProduction_module.cc
+++ b/HyperonProduction_module.cc
@@ -180,36 +180,46 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
 		std::vector<int> sigmaZeroDaughter_ids;
 		std::vector<int> lambdaDaughter_ids;
 
-		// output tree values here:
-
+        /////////////////////////////
+		// Event ID
+        /////////////////////////////
 		unsigned int _run;
 		unsigned int _subrun;
 		unsigned int _event;
 
-		int    _mc_nu_pdg;
-		double _mc_nu_pos_x;
-		double _mc_nu_pos_y;
-		double _mc_nu_pos_z;
-		double _mc_nu_q2;
-		int    _mc_lepton_pdg;
-		double _mc_lepton_mom;
-
-		std::string _mc_ccnc;
-		std::string _mc_mode;
-
+        /////////////////////////////
+		// Event MC Info
+        /////////////////////////////
 		unsigned int _n_mctruths;
+		std::string  _mc_ccnc;
+		std::string  _mc_mode;
+		int          _mc_nu_pdg;
+		double       _mc_nu_pos_x;
+		double       _mc_nu_pos_y;
+		double       _mc_nu_pos_z;
+		double       _mc_nu_q2;
+		int          _mc_lepton_pdg;
+		double       _mc_lepton_mom;
+        int          _true_nu_slice_ID;
+        double       _true_nu_slice_completeness;
+        double       _true_nu_slice_purity;
 
         unsigned int _n_slices;
-        int _true_nu_slice_ID;
-        double _true_nu_slice_completeness;
-        double _true_nu_slice_purity;
-        int _pandora_nu_slice_ID;
-        int _flash_match_nu_slice_ID;
         //unsigned int _n_primary_tracks;          // do we need these if we have multiple slices?
         //unsigned int _n_primary_showers;         // do we need these if we have multiple slices?
 
         /////////////////////////////
-		// RecoParticle fields
+		// FlashMatch Slice Info
+        /////////////////////////////
+        int _flash_match_nu_slice_ID;
+
+        /////////////////////////////
+		// Pandora Slice Info
+        /////////////////////////////
+        int _pandora_nu_slice_ID;
+
+        /////////////////////////////
+		// PFParticle Variables
         /////////////////////////////
         // True stuff
     	std::vector<double> _pfp_purity;
@@ -228,11 +238,13 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
         // Reco pfp stuff
 		std::vector<int>    _pfp_pdg;
 		std::vector<double> _pfp_trk_shr_score;
-		std::vector<double> _pfp_x;
-		std::vector<double> _pfp_y;
-		std::vector<double> _pfp_z;
+        std::vector<double> _pfp_x; // TODO: Set this!
+        std::vector<double> _pfp_y; // TODO: Set this! 
+        std::vector<double> _pfp_z; // TODO: Set this! 
 
-        // Reco track stuff
+        /////////////////////////////
+		// Track Variables
+        /////////////////////////////
 		std::vector<double> _trk_length;
 		std::vector<double> _trk_dir_x;
 		std::vector<double> _trk_dir_y;
@@ -247,9 +259,11 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
 		std::vector<double> _trk_mean_dedx_plane1;
 		std::vector<double> _trk_mean_dedx_plane2;
 		std::vector<double> _trk_three_plane_dedx;
-		std::vector<double> _trk_llrpid;
+        std::vector<double> _trk_llrpid; // TODO: Set this! 
 
-        // Reco shower stuff 
+        /////////////////////////////
+		// Shower Variables
+        /////////////////////////////
 		std::vector<double> _shr_length;
 		std::vector<double> _shr_dir_x;
 		std::vector<double> _shr_dir_y;
@@ -257,17 +271,22 @@ class hyperon::HyperonProduction : public art::EDAnalyzer {
 		std::vector<double> _shr_start_x;
 		std::vector<double> _shr_start_y;
 		std::vector<double> _shr_start_z;
-		std::vector<double> _shr_energy_plane0;
-		std::vector<double> _shr_energy_plane1;
-		std::vector<double> _shr_energy_plane2;
-		std::vector<double> _shr_dedx_plane0;
-		std::vector<double> _shr_dedx_plane1;
-		std::vector<double> _shr_dedx_plane2;
+        std::vector<double> _shr_energy_plane0; // TODO: Set this!
+        std::vector<double> _shr_energy_plane1; // TODO: Set this!
+        std::vector<double> _shr_energy_plane2; // TODO: Set this!
+        std::vector<double> _shr_dedx_plane0; // TODO: Set this!
+        std::vector<double> _shr_dedx_plane1; // TODO: Set this!
+        std::vector<double> _shr_dedx_plane2; // TODO: Set this!
 		std::vector<double> _shr_open_angle;
 
+        /////////////////////////////
+		// Tree
+        /////////////////////////////
 		TTree* fTree;
 
-        // Maps for analyzer
+        /////////////////////////////
+		// Internal analyzer maps
+        /////////////////////////////
         std::map<int, int> _hit_to_trackID;                 // Linking hit -> trackID of true owner
         std::map<int, art::Ptr<recob::Slice>> _slice_map;   // Linking sliceID -> slice
         std::map<int, std::vector<int>> _trackID_to_hits;   // Linking trackID -> nTrueHits
@@ -345,29 +364,45 @@ void hyperon::HyperonProduction::beginJob()
 	art::ServiceHandle<art::TFileService> tfs;
 	fTree = tfs->make<TTree>("OutputTree", "Output TTree");
 
+    /////////////////////////////
+    // Event ID
+    /////////////////////////////
 	fTree->Branch("run",    &_run);
 	fTree->Branch("subrun", &_subrun);
 	fTree->Branch("event",  &_event);
 
-	fTree->Branch("mc_nu_pdg",     &_mc_nu_pdg);
-	fTree->Branch("mc_nu_q2",      &_mc_nu_q2);
-	fTree->Branch("mc_ccnc",       &_mc_ccnc);
-	fTree->Branch("mc_mode",       &_mc_mode);
-	fTree->Branch("mc_nu_pos_x",   &_mc_nu_pos_x);
-	fTree->Branch("mc_nu_pos_y",   &_mc_nu_pos_y);
-	fTree->Branch("mc_nu_pos_z",   &_mc_nu_pos_z);
-	fTree->Branch("mc_lepton_pdg", &_mc_lepton_pdg);
-	fTree->Branch("mc_lepton_mom", &_mc_lepton_mom);
-
-	fTree->Branch("n_mctruths", &_n_mctruths);
-
-	fTree->Branch("n_slices",                    & _n_slices);
+    /////////////////////////////
+    // Event MC Info
+    /////////////////////////////
+	fTree->Branch("n_mctruths",                  &_n_mctruths);
+	fTree->Branch("mc_nu_pdg",                   &_mc_nu_pdg);
+	fTree->Branch("mc_nu_q2",                    &_mc_nu_q2);
+	fTree->Branch("mc_ccnc",                     &_mc_ccnc);
+	fTree->Branch("mc_mode",                     &_mc_mode);
+	fTree->Branch("mc_nu_pos_x",                 &_mc_nu_pos_x);
+	fTree->Branch("mc_nu_pos_y",                 &_mc_nu_pos_y);
+	fTree->Branch("mc_nu_pos_z",                 &_mc_nu_pos_z);
+	fTree->Branch("mc_lepton_pdg",               &_mc_lepton_pdg);
+	fTree->Branch("mc_lepton_mom",               &_mc_lepton_mom);
     fTree->Branch("true_nu_slice_ID",            & _true_nu_slice_ID);
     fTree->Branch("true_nu_slice_completeness",  & _true_nu_slice_completeness);
     fTree->Branch("true_nu_slice_purity",        & _true_nu_slice_purity);
-    fTree->Branch("pandora_nu_slice_ID",         & _pandora_nu_slice_ID);
+	fTree->Branch("n_slices",                    & _n_slices);
+
+    /////////////////////////////
+    // FlashMatch Slice Info
+    /////////////////////////////
     fTree->Branch("flash_match_nu_slice_ID",     & _flash_match_nu_slice_ID);
 
+    /////////////////////////////
+    // Pandora Slice Info
+    /////////////////////////////
+    fTree->Branch("pandora_nu_slice_ID",         & _pandora_nu_slice_ID);
+
+    /////////////////////////////
+    // PFParticle Variables
+    /////////////////////////////
+    // True stuff
     fTree->Branch("pfp_purity",        & _pfp_purity);
 	fTree->Branch("pfp_completeness",  & _pfp_completeness);
     fTree->Branch("pfp_has_truth",     & _pfp_has_truth);
@@ -381,13 +416,16 @@ void hyperon::HyperonProduction::beginJob()
 	fTree->Branch("pfp_true_length",   & _pfp_true_length);
 	fTree->Branch("pfp_true_origin",   & _pfp_true_origin);
 
+    // Reco pfp stuff
     fTree->Branch("pfp_pdg",            & _pfp_pdg);
     fTree->Branch("pfp_trk_shr_score",  & _pfp_trk_shr_score);
     fTree->Branch("pfp_x",              & _pfp_x);
     fTree->Branch("pfp_y",              & _pfp_y);
     fTree->Branch("pfp_z",              & _pfp_z);
 
-	//fTree->Branch("n_primary_tracks",        & _n_primary_tracks);
+    /////////////////////////////
+    // Track Variables
+    /////////////////////////////
 	fTree->Branch("trk_length",              & _trk_length);
 	fTree->Branch("trk_start_x",             & _trk_start_x);
 	fTree->Branch("trk_start_y",             & _trk_start_y);
@@ -402,16 +440,28 @@ void hyperon::HyperonProduction::beginJob()
 	fTree->Branch("trk_mean_dedx_plane1",    & _trk_mean_dedx_plane1);
 	fTree->Branch("trk_mean_dedx_plane2",    & _trk_mean_dedx_plane2);
 	fTree->Branch("trk_three_plane_dedx",    & _trk_three_plane_dedx);
+    fTree->Branch("trk_llrpid",              & _trk_llrpid);
 
+    /////////////////////////////
+    // Shower Variables
+    /////////////////////////////
+	fTree->Branch("shr_length",         & _shr_length);
+	fTree->Branch("shr_open_angle",     & _shr_open_angle);
+	fTree->Branch("shr_start_x",        & _shr_start_x);
+	fTree->Branch("shr_start_y",        & _shr_start_y);
+	fTree->Branch("shr_start_z",        & _shr_start_z);
+	fTree->Branch("shr_dir_x",          & _shr_dir_x);
+	fTree->Branch("shr_dir_y",          & _shr_dir_y);
+	fTree->Branch("shr_dir_z",          & _shr_dir_z);
+    fTree->Branch("shr_energy_plane0",  & _shr_energy_plane0);
+    fTree->Branch("shr_energy_plane1",  & _shr_energy_plane1);
+    fTree->Branch("shr_energy_plane2",  & _shr_energy_plane2);
+    fTree->Branch("shr_dedx_plane0",    & _shr_dedx_plane0);
+    fTree->Branch("shr_dedx_plane1",    & _shr_dedx_plane1);
+    fTree->Branch("shr_dedx_plane2",    & _shr_dedx_plane2);
+
+	//fTree->Branch("n_primary_tracks",        & _n_primary_tracks);
 	//fTree->Branch("n_primary_showers", &_n_primary_showers);
-	fTree->Branch("shr_length",        &_shr_length);
-	fTree->Branch("shr_open_angle",    &_shr_open_angle);
-	fTree->Branch("shr_start_x",       &_shr_start_x);
-	fTree->Branch("shr_start_y",       &_shr_start_y);
-	fTree->Branch("shr_start_z",       &_shr_start_z);
-	fTree->Branch("shr_dir_x",         &_shr_dir_x);
-	fTree->Branch("shr_dir_y",         &_shr_dir_y);
-	fTree->Branch("shr_dir_z",         &_shr_dir_z);
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -1067,33 +1117,54 @@ void hyperon::HyperonProduction::getBogusShowerVariables()
 // TODO: define and set NULL values for failure modes accessing slice, track, etc..
 void hyperon::HyperonProduction::clearTreeVariables()
 {
-	_n_mctruths                 = 0;
-	_n_slices                   = 0;
-    _true_nu_slice_ID           = -1;
-    _true_nu_slice_completeness = -999.0;
-    _true_nu_slice_purity       = -999.0;
-    _pandora_nu_slice_ID        = -1;
-    _flash_match_nu_slice_ID    = -1;
-
-	//_n_primary_tracks  = 0;
-	//_n_primary_showers = 0;
-
-	_mc_nu_pdg   = bogus::PDG;
-	_mc_nu_q2    = -1.0;
-	_mc_nu_pos_x = bogus::POS;
-	_mc_nu_pos_y = bogus::POS;
-	_mc_nu_pos_z = bogus::POS;
-
-	_mc_lepton_pdg = bogus::PDG;
-	_mc_lepton_mom = -1.0;
-
-	_mc_ccnc   = "";
-	_mc_mode   = "";
-
+    // ATTN: I DONT THINK THEY SHOULD BE HERE
+    //i.e. this function is called when there is no reco info
 	primary_ids.clear();
 	lambdaDaughter_ids.clear();
 	sigmaZeroDaughter_ids.clear();
 
+    /////////////////////////////
+    // Event ID
+    /////////////////////////////
+    _run = -999;
+    _subrun = -999;
+    _event = -999;
+
+    /////////////////////////////
+    // Event MC Info
+    /////////////////////////////
+	_n_mctruths                 = 0;
+	_mc_nu_pdg   = bogus::PDG;
+	_mc_nu_q2    = bogus::DOUBLE;
+	_mc_nu_pos_x = bogus::POS;
+	_mc_nu_pos_y = bogus::POS;
+	_mc_nu_pos_z = bogus::POS;
+	_mc_lepton_pdg = bogus::PDG;
+	_mc_lepton_mom = bogus::DOUBLE;
+	_mc_ccnc   = "";
+	_mc_mode   = "";
+    _true_nu_slice_ID           = -1;
+    _true_nu_slice_completeness = bogus::DOUBLE;
+    _true_nu_slice_purity       = bogus::DOUBLE;
+
+	_n_slices                   = 0;
+	//_n_primary_tracks  = 0;
+	//_n_primary_showers = 0;
+
+    /////////////////////////////
+    // FlashMatch Slice Info
+    /////////////////////////////
+    _flash_match_nu_slice_ID    = -1;
+
+    /////////////////////////////
+    // Pandora Slice Info
+    /////////////////////////////
+    _pandora_nu_slice_ID        = -1;
+
+    /////////////////////////////
+    // PFParticle Variables
+    /////////////////////////////
+    // True stuff
     _pfp_purity.clear();
     _pfp_completeness.clear();
     _pfp_has_truth.clear();
@@ -1107,12 +1178,16 @@ void hyperon::HyperonProduction::clearTreeVariables()
 	_pfp_true_length.clear();
 	_pfp_true_origin.clear();
 
+    // Reco pfp stuff
     _pfp_pdg.clear();
     _pfp_trk_shr_score.clear();
     _pfp_x.clear();
     _pfp_y.clear();
     _pfp_z.clear();
 
+    /////////////////////////////
+    // Track Variables
+    /////////////////////////////
 	_trk_length.clear();
 	_trk_dir_x.clear();
 	_trk_dir_y.clear();
@@ -1129,6 +1204,9 @@ void hyperon::HyperonProduction::clearTreeVariables()
 	_trk_three_plane_dedx.clear();
 	_trk_llrpid.clear();
 
+    /////////////////////////////
+    // Shower Variables
+    /////////////////////////////
 	_shr_length.clear();
 	_shr_dir_x.clear();
 	_shr_dir_y.clear();

--- a/job/hyperonConfig.fcl
+++ b/job/hyperonConfig.fcl
@@ -4,19 +4,20 @@ analyzeEvents:
 {
     module_type:        "HyperonProduction"
 
-    PFParticleLabel:    "pandora"
-    ShowerLabel:        "pandora"
-    SliceLabel:         "pandora"
-    TrackLabel:         "pandora"
-    CaloLabel:          "pandoracaliSCE"
-    GeneratorLabel:     "generator"
-    G4Label:            "largeant"
-    PIDLabel:           "pandoracalipidSCE"
-    HitLabel:           "gaushit"
-    TrackHitAssnsLabel: "pandora"
-    HitTruthAssnsLabel: "gaushitTruthMatch"
+    PandoraRecoLabel:    "pandoraPatRec:allOutcomes"
+    FlashMatchRecoLabel: "pandora"
+    ShowerLabel:         "pandoraAllOutcomesShowerRedo"
+    TrackLabel:          "pandoraAllOutcomesTrackRedo"
+    CaloLabel:           "pandoraCaliAllOutcomesSCE"
+    GeneratorLabel:      "generator"
+    G4Label:             "largeant"
+    PIDLabel:            "pandoraPIDAllOutcomesSCE"
+    HitLabel:            "gaushit"
+    TrackHitAssnsLabel:  "pandoraPatRec:allOutcomes"
+    HitTruthAssnsLabel:  "gaushitTruthMatch"
 
-    Debug:              false
+    Debug:                false
+    IsData:               false
 }
 
 END_PROLOG

--- a/job/run_HyperonProduction.fcl
+++ b/job/run_HyperonProduction.fcl
@@ -1,34 +1,237 @@
 #include "hyperonConfig.fcl"
+#include "pandoramodules_microboone.fcl"
+#include "reco_uboone_mcc9_8_driver_overlay_stage2.fcl"
 //#include "reco_uboone_mcc9_8_driver_overlay_stage2.fcl"
-#include "services_microboone.fcl"
+//#include "services_microboone.fcl"
 
 process_name: HyperonSelection
 
-source:
-{
-    module_type: RootInput
-    fileNames: [
-       "/uboone/data/users/npatel7/testfiles/hyperons/v08_00_00_51/PhysicsRun-2018_6_25_7_7_38-0017394-00138_20180718T202142_ext_unbiased_2_20220306T081112_simmxd_detsim_mix_r1a_r1b_20220306T134556_reco1c_20220308T140_154b7c86-d5bf-44de-a58d-2162253181c5.root"
-    ]
-    maxEvents:   -1
-}
-
-services:
-{
-    TFileService: { fileName: "analysisOutput.root" }
-    //FileCatalogMetadata: @local::art_file_catalog_mc
-    @table::microboone_services
-}
-
 physics:
 {
-    analyzers:
-    {
-        ana: @local::analyzeEvents
+  producers: {
+    pandoraAllOutcomesTrackRedo: @local::microboone_pandoraTrackCreation
+    pandoraAllOutcomesShowerRedo: @local::microboone_pandoraShowerCreation
+
+    pandoraCaloAllOutcomes: {
+         CaloAlg: {
+            CalAmpConstants: [
+               5.82554e-4,
+               1.16594e-3
+            ]
+            CalAreaConstants: [
+               4.31e-3,
+               4.02e-3,
+               4.1e-3
+            ]
+            CaloDoLifeTimeCorrection: true
+            CaloLifeTimeForm: 0
+            CaloUseModBox: true
+         }
+         CorrectSCE: false
+         Flip_dQdx: false
+         SpacePointModuleLabel: "pandoraPatRec:allOutcomes"
+         T0ModuleLabel: "mctrutht0"
+         TrackModuleLabel: "pandoraAllOutcomesTrackRedo"
+         UseArea: true
+         module_type: "Calorimetry"
     }
 
-    p0: [ ana ]
-    end_paths: [ p0 ]
+    pandoraCaloAllOutcomesSCE: {
+         CaloAlg: {
+            CalAmpConstants: [
+               5.82554e-4,
+               1.16594e-3
+            ]
+            CalAreaConstants: [
+               4.31e-3,
+               4.02e-3,
+               4.1e-3
+            ]
+            CaloDoLifeTimeCorrection: true
+            CaloLifeTimeForm: 0
+            CaloUseModBox: true
+         }
+         CorrectSCE: true
+         Flip_dQdx: false
+         SpacePointModuleLabel: "pandoraPatRec:allOutcomes"
+         T0ModuleLabel: "mctrutht0"
+         TrackModuleLabel: "pandoraAllOutcomesTrackRedo"
+         UseArea: true
+         module_type: "Calorimetry"
+    }
+
+    pandoraCaliAllOutcomes: {
+         CalibrationFileName: "calibration_mcc8.4_v1.root"
+         CaloAlg: {
+            CalAmpConstants: [
+               5.82554e-4,
+               1.16594e-3
+            ]
+            CalAreaConstants: [
+               4.31e-3,
+               4.02e-3,
+               4.1e-3
+            ]
+            CaloDoLifeTimeCorrection: false
+            CaloLifeTimeForm: 0
+            CaloUseModBox: true
+         }
+         CalorimetryModuleLabel: "pandoraCaloAllOutcomes"
+         Corr_X: [
+            "correction_x_plane0",
+            "correction_x_plane1",
+            "correction_x_plane2"
+         ]
+         Corr_YZ: [
+            "correction_yz_plane0",
+            "correction_yz_plane1",
+            "correction_yz_plane2"
+         ]
+         CorrectSCE: false
+         ELifetimeCorrection: true
+         ForceUnity: true
+         ModBoxA: 9.3e-1
+         ModBoxB: 2.12e-1
+         TrackModuleLabel: "pandoraAllOutcomesTrackRedo"
+         UseRecoTrackDir: true
+         module_type: "CalibrationdEdX"
+    }
+
+    pandoraCaliAllOutcomesSCE: {
+         CalibrationFileName: "calibration_mcc8.4_v1.root"
+         CaloAlg: {
+            CalAmpConstants: [
+               5.82554e-4,
+               1.16594e-3
+            ]
+            CalAreaConstants: [
+               4.31e-3,
+               4.02e-3,
+               4.1e-3
+            ]
+            CaloDoLifeTimeCorrection: false
+            CaloLifeTimeForm: 0
+            CaloUseModBox: true
+         }
+         CalorimetryModuleLabel: "pandoraCaloAllOutcomesSCE"
+         Corr_X: [
+            "correction_x_plane0",
+            "correction_x_plane1",
+            "correction_x_plane2"
+         ]
+         Corr_YZ: [
+            "correction_yz_plane0",
+            "correction_yz_plane1",
+            "correction_yz_plane2"
+         ]
+         CorrectSCE: true
+         ELifetimeCorrection: true
+         ForceUnity: true
+         ModBoxA: 9.3e-1
+         ModBoxB: 2.12e-1
+         TrackModuleLabel: "pandoraAllOutcomesTrackRedo"
+         UseRecoTrackDir: true
+         module_type: "CalibrationdEdX"
+    }
+
+    pandoraPIDAllOutcomes: {
+         BraggAlgo: {
+            EndPointFloatLong: 2
+            EndPointFloatShort: -2
+            EndPointFloatStepSize: 5e-2
+            LikelihoodMapsFile: "${UBOONEDATA_DIR}/ParticleID/BraggLikelihoodMaps_mcc8_20190215.root"
+            NHitsToDrop: 1
+         }
+         Chi2PIDAlg: {
+            TemplateFile: "dEdxrestemplates.root"
+            UseMedian: true
+         }
+         DaughterFinderCutDistance: 5
+         DaughterFinderCutFraction: 5e-1
+         FiducialVolume: {
+            X_HIGH: 10
+            X_LOW: 10
+            Y_HIGH: 10
+            Y_LOW: 10
+            Z_HIGH: 10
+            Z_LOW: 10
+         }
+         ProducerLabels: {
+            CaloTrackAssn: "pandoraCaloAllOutcomes"
+            CalorimetryLabel: "pandoraCaloAllOutcomes"
+            HitLabel: "gaushit"
+            HitTrackAssn: "pandoraAllOutcomesTrackRedo"
+            HitTruthAssn: "gaushitTruthMatch"
+            ParticleIdLabel: "pid::particleid"
+            TrackLabel: "pandoraAllOutcomesTrackRedo"
+         }
+         module_type: "ParticleId"
+      }
+
+      pandoraPIDAllOutcomesSCE: {
+         BraggAlgo: {
+            EndPointFloatLong: 2
+            EndPointFloatShort: -2
+            EndPointFloatStepSize: 5e-2
+            LikelihoodMapsFile: "${UBOONEDATA_DIR}/ParticleID/BraggLikelihoodMaps_mcc8_20190215.root"
+            NHitsToDrop: 1
+         }
+         Chi2PIDAlg: {
+            TemplateFile: "dEdxrestemplates.root"
+            UseMedian: true
+         }
+         DaughterFinderCutDistance: 5
+         DaughterFinderCutFraction: 5e-1
+         FiducialVolume: {
+            X_HIGH: 10
+            X_LOW: 10
+            Y_HIGH: 10
+            Y_LOW: 10
+            Z_HIGH: 10
+            Z_LOW: 10
+         }
+         ProducerLabels: {
+            CaloTrackAssn: "pandoraCaloAllOutcomesSCE"
+            CalorimetryLabel: "pandoraCaloAllOutcomesSCE"
+            HitLabel: "gaushit"
+            HitTrackAssn: "pandoraAllOutcomesTrackRedo"
+            HitTruthAssn: "gaushitTruthMatch"
+            ParticleIdLabel: "pid::particleid"
+            TrackLabel: "pandoraAllOutcomesTrackRedo"
+         }
+         module_type: "ParticleId"
+      }
+  }
+
+  analyzers:
+  {
+      ana: @local::analyzeEvents
+  }
+
+  prod: [ pandoraAllOutcomesTrackRedo, pandoraAllOutcomesShowerRedo, pandoraCaloAllOutcomes, pandoraCaliAllOutcomes, pandoraPIDAllOutcomes, pandoraCaloAllOutcomesSCE, pandoraCaliAllOutcomesSCE, pandoraPIDAllOutcomesSCE ]
+
+  # Change root file
+  trigger_paths: [ prod ] 
+
+  path0 : [ ana ]
+
+  # Do not change root file
+  end_paths: [ path0 ]
+}
+
+outputs:
+{
+  out1:
+  {
+    module_type:      RootOutput
+    fileName:         "outfile_%#.root"
+    dataTier:         "full-reconstructed"
+    fileProperties:
+    {
+      maxInputFiles:  1
+      granularity:    "InputFile"
+    }
+  }
 }
 
 // outputs: {         }
@@ -44,5 +247,11 @@ services.SpaceCharge.EnableSimEfieldSCE:              true
 services.SpaceCharge.RepresentationType:              "Voxelized_TH3"
 services.SpaceCharge.CalibrationInputFilename:        "SpaceCharge/SCEoffsets_dataDriven_combined_bkwd_Jan18.root"
 
+physics.producers.pandoraAllOutcomesTrackRedo.PFParticleLabel:  "pandoraPatRec:allOutcomes"
+physics.producers.pandoraAllOutcomesShowerRedo.PFParticleLabel: "pandoraPatRec:allOutcomes"
+physics.producers.pandoraAllOutcomesTrackRedo.UseAllParticles:   true
+physics.producers.pandoraAllOutcomesShowerRedo.UseAllParticles:  true
+
 physics.analyzers.ana.IsData:                         false
+physics.analyzers.ana.Debug:                          true
 


### PR DESCRIPTION
- Added in topological/flash match slice IDs
- Re-implemented the true->reco particle matching
- Tidied some code into functions
- Fitting every particle as both a track and a shower

Checked that this new commit reproduces the output of the current analyser. There is only one slight different which is the dEdx values of the tracks. They differ at about the 4th/5th decimal place. I can't work out why.. I've checked that the pandoraCaloSCE/pandoraCaliSCE match with the uboone workflow via a fhicl-dump. Since it is such a small difference, I don't think we need to worry.  I haven't been able to check the pandoraPIDSCE since the llr_pid score hasn't been implemented. This **WILL NEED CHECKING** since i'm not convinced about the labels here.

Finally, we need to move the 'fillNull' instance if no reco products are found. This is because we don't want to clear the truth info from our tree entry.

TLDR TODO:
- check PID works
- think about fillNull instance
- soak test